### PR TITLE
XMLHelpers fix for py3: convert image data bytes to a unicode string

### DIFF
--- a/pywinauto/XMLHelpers.py
+++ b/pywinauto/XMLHelpers.py
@@ -108,7 +108,7 @@ def _SetNodeProps(element, name, value):
                 raise MemoryError
 
             #print('type(value) = ' + str(type(value)))
-            image_data = codecs.encode(codecs.encode(value.tobytes(), "bz2"), "base64")
+            image_data = codecs.encode(codecs.encode(value.tobytes(), "bz2"), "base64").decode('utf-8')
             _SetNodeProps(
                 element,
                 name + "_IMG",


### PR DESCRIPTION
Let me explain the fix. On Python 3 the following line produces a *bytes-like object*:
```python
image_data = codecs.encode(codecs.encode(value.tobytes(), "bz2"), "base64")
```
And a line in *_EscapeSpecials* fails to convert it to string:
```python
string = six.text_type(string)
```
The right conversion  in *_EscapeSpecials* could be done with specifying an encoding argument for the conversion, but it would require a more CPU-expensive type validation on every call, something like this:
```python
if isinstance(string, six.binary_type):
    string = six.text_type(string, encoding='utf-8')
else:
    string = six.text_type(string)
```

