### PR TITLE
handleprops: add is64bitprocess proc

### DIFF
--- a/pywinauto/controls/HwndWrapper.py
+++ b/pywinauto/controls/HwndWrapper.py
@@ -203,6 +203,9 @@ class HwndWrapper(object): # six.with_metaclass(_MetaWrapper, object)
         # make it so that ctypes conversion happens correctly
         self._as_parameter_ = self.handle
 
+        # TODO: 32 or 64 bits process running on x64
+        #self.is64bitprocess = handleprops.is64bitprocess(self.ProcessID())
+
         #win32functions.WaitGuiThreadIdle(self)
 
         # specify whether we need to grab an image of ourselves

--- a/pywinauto/handleprops.py
+++ b/pywinauto/handleprops.py
@@ -141,6 +141,23 @@ def isenabled(handle):
     return bool(win32functions.IsWindowEnabled(handle))
 
 #=========================================================================
+def is64bitprocess(process_id):
+    """Return True if the specified process is a 64-bit process on x64
+       and False if it is only a 32-bit process running under Wow64.
+       Always return False for x86"""
+
+    from pywinauto.sysinfo import is_x64_OS
+    is32 = True
+    if is_x64_OS():
+        import win32process, win32api
+        phndl = win32api.OpenProcess(0x400, 0, process_id)
+        if phndl:
+          is32 = win32process.IsWow64Process(phndl)
+          #print("is64bitprocess, is32: %d, procid: %d" % (is32, process_id))
+        
+    return (not is32)
+
+#=========================================================================
 def clientrect(handle):
     "Return the client rectangle of the control"
     client_rect = win32structures.RECT()

--- a/pywinauto/unittests/test_handleprops.py
+++ b/pywinauto/unittests/test_handleprops.py
@@ -24,11 +24,13 @@ __revision__ = "$Revision: 234 $"
 
 import unittest
 
+import os
 import sys
 sys.path.append(".")
 from pywinauto.handleprops import *
 from pywinauto.application import Application
 from pywinauto import six
+from pywinauto.sysinfo import is_x64_OS
 
 
 class handlepropsTestCases(unittest.TestCase):
@@ -220,7 +222,32 @@ class handlepropsTestCases(unittest.TestCase):
 #        self.app.UntitledNotepad.MenuSelect("Edit->Replace")
 #        self.assertEquals("Dialog", friendlyclassname(self.app.Replace.handle))
 #        self.app.Replace.Cancel.Click()
+    def test_is64bitprocess(self):
+        "Make sure a 64-bit process detection returns correct results"
+ 
+        if is_x64_OS():
+            # Test a 32-bit app running on x64
+            expected_is64bit = False
+            exe32bit = os.path.join(os.path.dirname(__file__),
+                          r"..\..\apps\MFC_samples\RowList.exe")
+            app = Application().start_(exe32bit)
+            pid = app.RowListSampleApplication.ProcessID()
+            res_is64bit = is64bitprocess(pid)
+            try:
+              self.assertEquals(expected_is64bit, res_is64bit)
+            finally:
+              # make sure to close an additional app we have opened
+              app.kill_()
 
+            # setup expected for a 64-bit app on x64
+            expected_is64bit = True
+        else:
+            # setup expected for a 32-bit app on x86
+            expected_is64bit = False
+
+        # test native Notepad app
+        res_is64bit = is64bitprocess(self.app.UntitledNotepad.ProcessID())
+        self.assertEquals(expected_is64bit, res_is64bit)
 
     def test_dumpwindow(self):
         "Make sure the friendly class is set correctly"


### PR DESCRIPTION
I added an utility function to detect if the process we launched is 64-bit or  a 32-bit process under Wow64. As I mentioned in #28, I think we will need this kind of property in HwndWrapper to prepare different memory layouts when sending messages to a remote process. @vasily-v-ryabov if you are OK with it you can merge it into the master branch.